### PR TITLE
Added gunzip, zlib decompression support and revamped API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # tiny-inflate
 
 This is a port of Joergen Ibsen's [tiny inflate](https://bitbucket.org/jibsen/tinf) to JavaScript.
-Minified it is about 3KB, or 1.3KB gzipped. While being very small, it is also reasonably fast
+Minified it is about 3.7KB, or 1.5KB gzipped. While being very small, it is also reasonably fast
 (about 30% - 50% slower than [pako](https://github.com/nodeca/pako) on average), and should be 
 good enough for many applications. If you need the absolute best performance, however, you'll
 need to use a larger library such as pako that contains additional optimizations.
@@ -12,18 +12,47 @@ need to use a larger library such as pako that contains additional optimizations
 
 ## Example
 
-To use tiny-inflate, you need two things: a buffer of data compressed with deflate,
-and the decompressed size (often stored in a file header) to allocate your output buffer.
-Input and output buffers can be either node `Buffer`s, or `Uint8Array`s.
+To use tiny-inflate, you only need a buffer of data compressed with `deflate`, `zlib`, or `gzip`.
 
+If you have the decompressed size, you can allocate your output buffer ahead of time to save memory.
+(Note that this is unecessary for GZIP data because `tiny-inflate` automatically detects the output
+size from the header.)
+
+Input and output buffers must be `Uint8Array`s. Since `Buffer`s are instances of `Uint8Array`s, you can 
+also pass those in directly.
+
+`tiny-inflate` will try to automatically detect what compression method the data is in, but in rare cases 
+it fails. If that happens, you can use `inflate.gunzip()` for GZIP data (like `pako.ungzip()`), 
+`inflate.inflate()` for deflated data (like `pako.inflateRaw()`), and `inflate.decompress()` for Zlib data 
+(like `pako.inflate()`).
+
+
+Example: decoding a Base64, GZIP string to the source string
 ```javascript
 var inflate = require('tiny-inflate');
 
-var compressedBuffer = new Bufer([ ... ]);
-var decompressedSize = ...;
-var outputBuffer = new Buffer(decompressedSize);
+var compressedBuffer = Buffer.from('H4sIAAAAAAAAA/NIzcnJVyjPL8pJUQQAlRmFGwwAAAA=', 'base64');
 
-inflate(compressedBuffer, outputBuffer);
+var outputUint8Array = inflate(compressedBuffer); /* Can also use inflate.gunzip(compressedBuffer) */
+
+var outputBuffer = Buffer.from(outputUint8Array);
+
+console.log(outputBuffer.toString('utf8')); /* Hello world! */
+```
+Example: efficiently decoding a Base64, Zlib string with known uncompressed length
+```javascript
+var inflate = require('tiny-inflate');
+
+var compressedBuffer = Buffer.from('eJzzSM3JyVcozy/KSVEEAB0JBF4=', 'base64');
+
+var outputSize = 12; /* Assuming you know this previously... */
+
+var outputArray = new Uint8Array(outputSize); /* Then you can create an efficient output space */
+
+/* Output array that is passed in is mutated - no need to extract return value */ 
+inflate(compressedBuffer, outputArray); /* Can also use inflate.inflate(compressedBuffer, outputArray) */
+
+console.log(Buffer.from(outputArray).toString('utf8')); /* Hello world! */
 ```
 
 ## License


### PR DESCRIPTION
I added basic support for `zlib` and `gzip` input (little validation - focused on performance and file size), as well as autodetection of format. This makes the API a lot easier to use for those with `zlib`/`gzip` data. I also added JSDoc and type annotations for the methods, which allows for better autocomplete and TypeScript support.

Possibly most importantly of all, I made the second parameter (the output array) optional, so that those without knowledge of the output size can still use this awesome library. It will automatically use an (admittedly inefficient) standard array to store the result of the decompression before switching to a `Uint8Array`. If the data is gzipped, a header tells us the output file size, so we use that to maximize memory efficiency. The new API is still 100% compatible with the old API.

Thanks for creating this wonderful library!