### PR TITLE
Avoid publishing tests to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.3",
   "description": "A tiny inflate implementation",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
This PR adds a `files` field to `package.json` to limit what gets published to npm. Currently tests make up about 75% of the package size on npm, so omitting them when publishing is a nice reduction in install size.